### PR TITLE
Delete bad import in DataTransformation/py

### DIFF
--- a/resource/python/DataTransformation.py
+++ b/resource/python/DataTransformation.py
@@ -1,5 +1,4 @@
 import dataiku
-from dataiku import os
 import json
 import os
 import logging


### PR DESCRIPTION
The line 'from dataiku import os' is an incorrect statement. It appears to pass muster when testing in DSS 6.x but throws an error in DSS 7.x.